### PR TITLE
Fix RegEx used to parse attachment filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ Maven Central
 <dependency>
     <groupId>ch.racic.selenium.helper</groupId>
     <artifactId>SeleniumDownloadHelper</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.2</version>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>ch.racic.selenium.helper</groupId>
     <artifactId>SeleniumDownloadHelper</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.3.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Selenium Download Helper library</name>
@@ -211,7 +211,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <useReleaseProfile>false</useReleaseProfile>

--- a/src/main/resources/ch/racic/selenium/helper/download/js/seleniumDownloadHelper.js
+++ b/src/main/resources/ch/racic/selenium/helper/download/js/seleniumDownloadHelper.js
@@ -30,10 +30,10 @@ var seleniumDownloadHelper = {
         var disp = xhr.getResponseHeader('Content-Disposition');
         var fileName = "";
         if (disp && disp.search('filename') != -1) {
-            var filenamePattern = "filename=\"(.*)\".*";
-            var re = new RegExp(filenamePattern);
-            if (re.test(disp)) {
-                fileName = re.exec(disp)[1];
+            var filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+            if (filenameRegex.test(disp)) {
+                fileName = filenameRegex.exec(disp)[1].replace(/['"]/g, '');
+                fileName = decodeURIComponent(fileName);
             }
         }
 


### PR DESCRIPTION
Previous code comment says "Code taken from http://stackoverflow.com/q/16086162", but copied incorrectly. Filename may be enclosed in single quotes, double quotes or no quotes at all.
Additionally added decodeURIComponent() to get a proper filename.